### PR TITLE
Fix 'claim' menu-item not showing when MM is disconnected

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -16,7 +16,7 @@
         />
       </a>
       <ul class="header-menu">
-        <li *ngIf="leftDaysInfoShow" class="header-menu_item">
+        <li class="header-menu_item">
           <a
             routerLink="claim"
             routerLinkActive="active-link"


### PR DESCRIPTION
![fix-menu-item](https://user-images.githubusercontent.com/75571904/101696933-346cd900-3a77-11eb-996b-689f132a176c.png)

Fixes "claim" menu item not showing when MM is disconnected.

Users should know they can claim/freeclam on stake.axion.network before they connect with MM.